### PR TITLE
Add official 1.20.6 support

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -9,13 +9,13 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Validate Gradle Wrapper
         uses: gradle/wrapper-validation-action@v1
       - name: Setup Java
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: 17
+          java-version: 21
       - name: Build on ${{ matrix.os }}
         run: ./gradlew clean build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,15 +11,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Validate Gradle Wrapper
         uses: gradle/wrapper-validation-action@v1
       - name: Setup Java
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: temurin
           cache: gradle
-          java-version: 17
+          java-version: 21
       - name: Publish
         env:
           HANGAR_SECRET: ${{secrets.HANGAR_KEY}}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,4 @@
 import io.papermc.hangarpublishplugin.model.Platforms
-import java.util.*
 import net.minecrell.pluginyml.bukkit.BukkitPluginDescription
 import xyz.jpenilla.runpaper.task.RunServer
 
@@ -81,12 +80,10 @@ dependencies {
     // Stats
     implementation("org.bstats:bstats-bukkit:3.0.2")
     // Commands
-    implementation("cloud.commandframework:cloud-annotations:1.8.3")
-    implementation("cloud.commandframework:cloud-minecraft-extras:1.8.3")
-    implementation("cloud.commandframework:cloud-paper:1.8.3")
-    annotationProcessor("cloud.commandframework:cloud-annotations:1.8.3")
-    implementation("me.lucko:commodore:2.2")
-
+    implementation("org.incendo:cloud-annotations:2.0.0-rc.2")
+    implementation("org.incendo:cloud-minecraft-extras:2.0.0-beta.8")
+    implementation("org.incendo:cloud-paper:2.0.0-beta.8")
+    annotationProcessor("org.incendo:cloud-annotations:2.0.0-rc.2")
 }
 
 bukkit {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,12 +8,12 @@ plugins {
     `java-library`
     id("olf.build-logic")
     id("com.diffplug.spotless") version "6.18.0"
-    id("com.github.johnrengelman.shadow") version "8.1.1"
+    id("io.github.goooler.shadow") version "8.1.7"
     id("net.minecrell.plugin-yml.bukkit") version "0.5.3"
-    id("xyz.jpenilla.run-paper") version "2.1.0"
+    id("xyz.jpenilla.run-paper") version "2.3.0"
     idea
 
-    id("io.papermc.hangar-publish-plugin") version "0.0.5"
+    id("io.papermc.hangar-publish-plugin") version "0.1.2"
     id("com.modrinth.minotaur") version "2.+"
 }
 
@@ -33,7 +33,7 @@ allprojects {
 }
 group = "net.onelitefeather.bettergopaint"
 
-val minecraftVersion = "1.20.2"
+val minecraftVersion = "1.20.6"
 val supportedMinecraftVersions = listOf(
     "1.16.5",
     "1.17",
@@ -50,7 +50,9 @@ val supportedMinecraftVersions = listOf(
     "1.20.1",
     "1.20.2",
     "1.20.3",
-    "1.20.4"
+    "1.20.4",
+    "1.20.5",
+    "1.20.6"
 )
 
 repositories {
@@ -130,7 +132,7 @@ spotless {
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(17))
+        languageVersion.set(JavaLanguageVersion.of(21))
     }
 }
 
@@ -139,7 +141,7 @@ tasks {
         archiveClassifier.set("unshaded")
     }
     compileJava {
-        options.release.set(17)
+        options.release.set(21)
         options.encoding = "UTF-8"
     }
     shadowJar {
@@ -185,8 +187,6 @@ if (!isRelease || isMainBranch) { // Only publish releases from the main branch
             channel.set(if (isRelease) "Release" else if (isMainBranch) "Snapshot" else "Alpha")
             changelog.set(changelogContent)
             apiKey.set(System.getenv("HANGAR_SECRET"))
-            owner.set("TheMeinerLP")
-            slug.set("BetterGoPaint")
             platforms {
                 register(Platforms.PAPER) {
                     jar.set(tasks.shadowJar.flatMap { it.archiveFile })

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -34,17 +34,6 @@ group = "net.onelitefeather.bettergopaint"
 
 val minecraftVersion = "1.20.6"
 val supportedMinecraftVersions = listOf(
-    "1.16.5",
-    "1.17",
-    "1.17.1",
-    "1.18",
-    "1.18.1",
-    "1.18.2",
-    "1.19",
-    "1.19.1",
-    "1.19.2",
-    "1.19.3",
-    "1.19.4",
     "1.20",
     "1.20.1",
     "1.20.2",

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-projectVersion=1.0.0
+projectVersion=1.1.0
 
 org.gradle.jvmargs=-Xmx2048m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
 org.gradle.daemon=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.1.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/net/onelitefeather/bettergopaint/BetterGoPaint.java
+++ b/src/main/java/net/onelitefeather/bettergopaint/BetterGoPaint.java
@@ -18,14 +18,9 @@
  */
 package net.onelitefeather.bettergopaint;
 
-import cloud.commandframework.annotations.AnnotationParser;
-import cloud.commandframework.arguments.parser.ParserParameters;
-import cloud.commandframework.arguments.parser.StandardParameters;
-import cloud.commandframework.bukkit.CloudBukkitCapabilities;
-import cloud.commandframework.execution.CommandExecutionCoordinator;
-import cloud.commandframework.meta.CommandMeta;
-import cloud.commandframework.paper.PaperCommandManager;
 import com.fastasyncworldedit.core.Fawe;
+import io.papermc.lib.PaperLib;
+import net.kyori.adventure.text.minimessage.MiniMessage;
 import net.onelitefeather.bettergopaint.command.Handler;
 import net.onelitefeather.bettergopaint.command.ReloadCommand;
 import net.onelitefeather.bettergopaint.listeners.ConnectListener;
@@ -35,20 +30,21 @@ import net.onelitefeather.bettergopaint.objects.other.Settings;
 import net.onelitefeather.bettergopaint.objects.player.PlayerBrushManager;
 import net.onelitefeather.bettergopaint.utils.Constants;
 import net.onelitefeather.bettergopaint.utils.DisabledBlocks;
-import io.papermc.lib.PaperLib;
-import net.kyori.adventure.text.minimessage.MiniMessage;
 import org.bstats.bukkit.Metrics;
 import org.bstats.charts.SimplePie;
 import org.bukkit.command.CommandSender;
 import org.bukkit.event.Listener;
 import org.bukkit.plugin.PluginManager;
 import org.bukkit.plugin.java.JavaPlugin;
+import org.incendo.cloud.annotations.AnnotationParser;
+import org.incendo.cloud.bukkit.CloudBukkitCapabilities;
+import org.incendo.cloud.execution.ExecutionCoordinator;
+import org.incendo.cloud.paper.LegacyPaperCommandManager;
 import org.incendo.serverlib.ServerLib;
 
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
-import java.util.function.Function;
 import java.util.logging.Level;
 
 
@@ -164,24 +160,15 @@ public class BetterGoPaint extends JavaPlugin implements Listener {
 
     private void enableCommandSystem() {
         try {
-            PaperCommandManager<CommandSender> commandManager = PaperCommandManager.createNative(
+            LegacyPaperCommandManager<CommandSender> commandManager = LegacyPaperCommandManager.createNative(
                     this,
-                    CommandExecutionCoordinator.simpleCoordinator()
+                    ExecutionCoordinator.simpleCoordinator()
             );
             if (commandManager.hasCapability(CloudBukkitCapabilities.BRIGADIER)) {
                 commandManager.registerBrigadier();
                 getLogger().info("Brigadier support enabled");
             }
-            if (commandManager.hasCapability(CloudBukkitCapabilities.ASYNCHRONOUS_COMPLETION)) {
-                commandManager.registerAsynchronousCompletions();
-                getLogger().info("Async completion support enabled");
-            }
-            Function<ParserParameters, CommandMeta> commandMetaFunction = parserParameters ->
-                    CommandMeta
-                            .simple()
-                            .with(CommandMeta.DESCRIPTION, parserParameters.get(StandardParameters.DESCRIPTION, "No description"))
-                            .build();
-            this.annotationParser = new AnnotationParser<>(commandManager, CommandSender.class, commandMetaFunction);
+            this.annotationParser = new AnnotationParser<>(commandManager, CommandSender.class);
 
         } catch (Exception e) {
             getLogger().log(Level.SEVERE, "Cannot init command manager");

--- a/src/main/java/net/onelitefeather/bettergopaint/command/ReloadCommand.java
+++ b/src/main/java/net/onelitefeather/bettergopaint/command/ReloadCommand.java
@@ -18,10 +18,10 @@
  */
 package net.onelitefeather.bettergopaint.command;
 
-import cloud.commandframework.annotations.CommandMethod;
-import cloud.commandframework.annotations.CommandPermission;
 import net.onelitefeather.bettergopaint.BetterGoPaint;
 import org.bukkit.entity.Player;
+import org.incendo.cloud.annotations.Command;
+import org.incendo.cloud.annotations.Permission;
 
 public final class ReloadCommand {
 
@@ -31,8 +31,8 @@ public final class ReloadCommand {
         this.betterGoPaint = betterGoPaint;
     }
 
-    @CommandMethod("bgp|gp reload")
-    @CommandPermission("bettergopaint.command.admin.reload")
+    @Command("bgp|gp reload")
+    @Permission("bettergopaint.command.admin.reload")
     public void onReload(Player player) {
         betterGoPaint.reload();
     }

--- a/src/main/java/net/onelitefeather/bettergopaint/objects/player/PlayerBrush.java
+++ b/src/main/java/net/onelitefeather/bettergopaint/objects/player/PlayerBrush.java
@@ -403,7 +403,7 @@ public class PlayerBrush {
             }
             im.setLore(loreList);
         }
-        im.addEnchant(Enchantment.ARROW_INFINITE, 10, true);
+        im.addEnchant(Enchantment.INFINITY, 10, true);
         im.addItemFlags(ItemFlag.HIDE_ENCHANTS);
         i.setItemMeta(im);
         return i;


### PR DESCRIPTION
## Description

This PR adds official support for 1.20.6
- cloud command framework was updated to utilize the latest addition of paper brigadier
- use gooolers shadowJar fork for java 21 support
- updated hangar publish and removed dead code from publication task
- updated workflows to use java 21
- removed dead versions from "supported" list

## Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [X] I included all information required in the sections above
- [X] I tested my changes and approved their functionality
- [X] I ensured my changes do not break other parts of the code
