### PR TITLE
add official 1.20.6 support

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -33,7 +33,7 @@ allprojects {
 }
 group = "net.onelitefeather.bettergopaint"
 
-val minecraftVersion = "1.20.2"
+val minecraftVersion = "1.20.6"
 val supportedMinecraftVersions = listOf(
     "1.16.5",
     "1.17",

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -79,11 +79,10 @@ dependencies {
     // Stats
     implementation("org.bstats:bstats-bukkit:3.0.2")
     // Commands
-    implementation("cloud.commandframework:cloud-annotations:1.8.3")
-    implementation("cloud.commandframework:cloud-minecraft-extras:1.8.3")
-    implementation("cloud.commandframework:cloud-paper:1.8.3")
-    annotationProcessor("cloud.commandframework:cloud-annotations:1.8.3")
-    implementation("me.lucko:commodore:2.2")
+    implementation("org.incendo:cloud-annotations:2.0.0-rc.2")
+    implementation("org.incendo:cloud-minecraft-extras:2.0.0-beta.8")
+    implementation("org.incendo:cloud-paper:2.0.0-beta.8")
+    annotationProcessor("org.incendo:cloud-annotations:2.0.0-rc.2")
 
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -50,7 +50,9 @@ val supportedMinecraftVersions = listOf(
     "1.20.1",
     "1.20.2",
     "1.20.3",
-    "1.20.4"
+    "1.20.4",
+    "1.20.5",
+    "1.20.6"
 )
 
 repositories {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -35,17 +35,6 @@ group = "net.onelitefeather.bettergopaint"
 
 val minecraftVersion = "1.20.6"
 val supportedMinecraftVersions = listOf(
-    "1.16.5",
-    "1.17",
-    "1.17.1",
-    "1.18",
-    "1.18.1",
-    "1.18.2",
-    "1.19",
-    "1.19.1",
-    "1.19.2",
-    "1.19.3",
-    "1.19.4",
     "1.20",
     "1.20.1",
     "1.20.2",

--- a/src/main/java/net/onelitefeather/bettergopaint/BetterGoPaint.java
+++ b/src/main/java/net/onelitefeather/bettergopaint/BetterGoPaint.java
@@ -26,6 +26,8 @@ import cloud.commandframework.execution.CommandExecutionCoordinator;
 import cloud.commandframework.meta.CommandMeta;
 import cloud.commandframework.paper.PaperCommandManager;
 import com.fastasyncworldedit.core.Fawe;
+import io.papermc.lib.PaperLib;
+import net.kyori.adventure.text.minimessage.MiniMessage;
 import net.onelitefeather.bettergopaint.command.Handler;
 import net.onelitefeather.bettergopaint.command.ReloadCommand;
 import net.onelitefeather.bettergopaint.listeners.ConnectListener;
@@ -35,8 +37,6 @@ import net.onelitefeather.bettergopaint.objects.other.Settings;
 import net.onelitefeather.bettergopaint.objects.player.PlayerBrushManager;
 import net.onelitefeather.bettergopaint.utils.Constants;
 import net.onelitefeather.bettergopaint.utils.DisabledBlocks;
-import io.papermc.lib.PaperLib;
-import net.kyori.adventure.text.minimessage.MiniMessage;
 import org.bstats.bukkit.Metrics;
 import org.bstats.charts.SimplePie;
 import org.bukkit.command.CommandSender;
@@ -48,7 +48,6 @@ import org.incendo.serverlib.ServerLib;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
-import java.util.function.Function;
 import java.util.logging.Level;
 
 

--- a/src/main/java/net/onelitefeather/bettergopaint/BetterGoPaint.java
+++ b/src/main/java/net/onelitefeather/bettergopaint/BetterGoPaint.java
@@ -18,13 +18,6 @@
  */
 package net.onelitefeather.bettergopaint;
 
-import cloud.commandframework.annotations.AnnotationParser;
-import cloud.commandframework.arguments.parser.ParserParameters;
-import cloud.commandframework.arguments.parser.StandardParameters;
-import cloud.commandframework.bukkit.CloudBukkitCapabilities;
-import cloud.commandframework.execution.CommandExecutionCoordinator;
-import cloud.commandframework.meta.CommandMeta;
-import cloud.commandframework.paper.PaperCommandManager;
 import com.fastasyncworldedit.core.Fawe;
 import io.papermc.lib.PaperLib;
 import net.kyori.adventure.text.minimessage.MiniMessage;
@@ -43,6 +36,10 @@ import org.bukkit.command.CommandSender;
 import org.bukkit.event.Listener;
 import org.bukkit.plugin.PluginManager;
 import org.bukkit.plugin.java.JavaPlugin;
+import org.incendo.cloud.annotations.AnnotationParser;
+import org.incendo.cloud.bukkit.CloudBukkitCapabilities;
+import org.incendo.cloud.execution.ExecutionCoordinator;
+import org.incendo.cloud.paper.LegacyPaperCommandManager;
 import org.incendo.serverlib.ServerLib;
 
 import java.io.File;
@@ -163,24 +160,15 @@ public class BetterGoPaint extends JavaPlugin implements Listener {
 
     private void enableCommandSystem() {
         try {
-            PaperCommandManager<CommandSender> commandManager = PaperCommandManager.createNative(
+            LegacyPaperCommandManager<CommandSender> commandManager = LegacyPaperCommandManager.createNative(
                     this,
-                    CommandExecutionCoordinator.simpleCoordinator()
+                    ExecutionCoordinator.simpleCoordinator()
             );
             if (commandManager.hasCapability(CloudBukkitCapabilities.BRIGADIER)) {
                 commandManager.registerBrigadier();
                 getLogger().info("Brigadier support enabled");
             }
-            if (commandManager.hasCapability(CloudBukkitCapabilities.ASYNCHRONOUS_COMPLETION)) {
-                commandManager.registerAsynchronousCompletions();
-                getLogger().info("Async completion support enabled");
-            }
-            Function<ParserParameters, CommandMeta> commandMetaFunction = parserParameters ->
-                    CommandMeta
-                            .simple()
-                            .with(CommandMeta.DESCRIPTION, parserParameters.get(StandardParameters.DESCRIPTION, "No description"))
-                            .build();
-            this.annotationParser = new AnnotationParser<>(commandManager, CommandSender.class, commandMetaFunction);
+            this.annotationParser = new AnnotationParser<>(commandManager, CommandSender.class);
 
         } catch (Exception e) {
             getLogger().log(Level.SEVERE, "Cannot init command manager");

--- a/src/main/java/net/onelitefeather/bettergopaint/command/ReloadCommand.java
+++ b/src/main/java/net/onelitefeather/bettergopaint/command/ReloadCommand.java
@@ -18,10 +18,10 @@
  */
 package net.onelitefeather.bettergopaint.command;
 
-import cloud.commandframework.annotations.CommandMethod;
-import cloud.commandframework.annotations.CommandPermission;
 import net.onelitefeather.bettergopaint.BetterGoPaint;
 import org.bukkit.entity.Player;
+import org.incendo.cloud.annotations.Command;
+import org.incendo.cloud.annotations.Permission;
 
 public final class ReloadCommand {
 
@@ -31,8 +31,8 @@ public final class ReloadCommand {
         this.betterGoPaint = betterGoPaint;
     }
 
-    @CommandMethod("bgp|gp reload")
-    @CommandPermission("bettergopaint.command.admin.reload")
+    @Command("bgp|gp reload")
+    @Permission("bettergopaint.command.admin.reload")
     public void onReload(Player player) {
         betterGoPaint.reload();
     }

--- a/src/main/java/net/onelitefeather/bettergopaint/objects/player/PlayerBrush.java
+++ b/src/main/java/net/onelitefeather/bettergopaint/objects/player/PlayerBrush.java
@@ -403,7 +403,7 @@ public class PlayerBrush {
             }
             im.setLore(loreList);
         }
-        im.addEnchant(Enchantment.ARROW_INFINITE, 10, true);
+        im.addEnchant(Enchantment.INFINITY, 10, true);
         im.addItemFlags(ItemFlag.HIDE_ENCHANTS);
         i.setItemMeta(im);
         return i;


### PR DESCRIPTION
## Description

This PR adds official support for 1.20.6
- cloud command framework was updated to utilize the latest addition of paper brigadier
- removed dead versions from "supported" list

## Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [x] I included all information required in the sections above
- [x] I tested my changes and approved their functionality
- [x] I ensured my changes do not break other parts of the code
